### PR TITLE
Supports any name for a `Time` attribute

### DIFF
--- a/lib/keepcon.rb
+++ b/lib/keepcon.rb
@@ -2,6 +2,7 @@ require 'yaml'
 require 'faraday'
 require 'active_support'
 require 'active_support/core_ext/object'
+require 'active_support/core_ext/time'
 
 require 'keepcon/client'
 require 'keepcon/context'

--- a/lib/keepcon/entity.rb
+++ b/lib/keepcon/entity.rb
@@ -50,8 +50,8 @@ module Keepcon
     def translate_to_xml_hash
       translation = translate.map do |k, v|
         case
-        when k == :datetime then [k, { content!: (v.to_f * 1_000).to_i }]
         when k == :author then [k, { :@type => :author, :content! => v }]
+        when v.acts_like?(:time) then [k, { content!: (v.to_f * 1_000).to_i }]
         when v.is_a?(Fixnum) then [k, { content!: v }]
         else ["#{k}!", { content!: cdata_section(v) }]
         end


### PR DESCRIPTION
Uses duck-typing and the methods provided by `activesupport` to check if a attribute acts like `Time`
