### PR TITLE
On async results request add the param `clientACK`

### DIFF
--- a/lib/keepcon/config/urls.yml
+++ b/lib/keepcon/config/urls.yml
@@ -6,4 +6,4 @@ content:
     sync: '/synchronic/moderate'
     async: '/input/contentSet'
   response:
-    async: '/output/contentSet?contextName=%{context_name}'
+    async: '/output/contentSet?contextName=%{context_name}&clientACK=true'

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -73,7 +73,8 @@ describe Keepcon::Client do
     let!(:faraday) { Faraday.new { |f| f.adapter :test, adapter } }
     let(:adapter) do
       Faraday::Adapter::Test::Stubs.new do |stub|
-        stub.put('/output/contentSet?contextName=user', '', headers) do |_env|
+        uri = '/output/contentSet?contextName=user&clientACK=true'
+        stub.put(uri, '', headers) do |_env|
           [200, {}, 'all-results-body']
         end
       end


### PR DESCRIPTION
- [x] the param `clientACK=true` is needed to inform keep con to stop resend their tagged data
